### PR TITLE
Adds Voyage VLS-128 driver implementation

### DIFF
--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -37,18 +37,8 @@
 namespace velodyne_rawdata
 {
   // Shorthand typedefs for point cloud representations
-  struct PointXYZIRB
-   {
-       PCL_ADD_POINT4D;                    // quad-word XYZ
-       float    intensity;                 ///< laser intensity reading
-       uint16_t ring;                      ///< laser ring number
-       uint16_t block;                     ///< packet datablock number
-       EIGEN_MAKE_ALIGNED_OPERATOR_NEW     // ensure proper alignment
-   } EIGEN_ALIGN16;
-
   typedef velodyne_pointcloud::PointXYZIR VPoint;
   typedef pcl::PointCloud<VPoint> VPointCloud;
-  // typedef pcl::PointCloud<PointXYZIRB> XYZIRBPointCloud;
 
   /**
    * Raw Velodyne packet constants and structures.
@@ -56,7 +46,7 @@ namespace velodyne_rawdata
   static const int BLOCK_SIZE = 100; // [bytes]
   static const int CHANNEL_SIZE = 3; // [bytes]
   static const int NUM_CHANS_PER_BLOCK = 32;
-  static const int BLOCK_DATA_SIZE = (NUM_CHANS_PER_BLOCK * CHANNEL_SIZE);
+  static const int BLOCK_DATA_SIZE = (NUM_CHANS_PER_BLOCK * CHANNEL_SIZE); // 32 * 3 = 96 bytes
   static const float  CHANNEL_TDURATION  =   2.304f;   // [µs] Channels corresponds to one laser firing
   static const float  SEQ_TDURATION      =  55.296f;   // [µs] Sequence is a set of laser firings including recharging
 
@@ -68,20 +58,26 @@ namespace velodyne_rawdata
   /** @todo make this work for both big and little-endian machines */
   static const uint16_t UPPER_BANK = 0xeeff;
   static const uint16_t LOWER_BANK = 0xddff;
-  
+
   /** Special Definitions for VLP16 support **/
   static const int    VLP16_NUM_SEQS_PER_BLOCK  = 2;
   static const int    VLP16_NUM_CHANS_PER_SEQ   = 16;
   static const float  VLP16_BLOCK_TDURATION     = (VLP16_NUM_SEQS_PER_BLOCK * SEQ_TDURATION);
- 
+
   /** Special Definitions for HDL32 support **/
   static const float  HDL32_CHANNEL_TDURATION  =   1.152f;   // [µs] From Application Note: HDL-32E Packet Structure and Timing Defition
   static const float  HDL32_SEQ_TDURATION      =  46.080f;   // [µs] Sequence is a set of laser firings including recharging
-  
-  /** Special Definition for VLS128 support **/
-  static const int VLS128_NUM_CHANS_PER_BLOCK = 128;
-  static const int VLS128_BLOCK_DATA_SIZE = VLS128_NUM_CHANS_PER_BLOCK * CHANNEL_SIZE;
-  
+
+  /** Special Definitions for VLS128 support **/
+  // These are used to detect which bank of 32 lasers is in this block
+  static const uint16_t VLS128_BANK_1 = 0xeeff;
+  static const uint16_t VLS128_BANK_2 = 0xddff;
+  static const uint16_t VLS128_BANK_3 = 0xccff;
+  static const uint16_t VLS128_BANK_4 = 0xbbff;
+
+  static const float  VLS128_CHANNEL_TDURATION  =  2.665f;  // [µs] Channels corresponds to one laser firing
+  static const float  VLS128_SEQ_TDURATION      =  53.3f;   // [µs] Sequence is a set of laser firings including recharging
+
   /** \brief Raw Velodyne data block.
    *
    *  Each block contains data from either the upper or lower laser
@@ -128,7 +124,7 @@ namespace velodyne_rawdata
   {
     raw_block_t blocks[NUM_BLOCKS_PER_PACKET];
     uint16_t revolution;
-    uint8_t status[PACKET_STATUS_SIZE]; 
+    uint8_t status[PACKET_STATUS_SIZE];
   } raw_packet_t;
 
   /** \brief Velodyne data conversion class */
@@ -152,11 +148,11 @@ namespace velodyne_rawdata
      */
     int setup(ros::NodeHandle private_nh);
 
-    /** \brief Set up for data processing offline. 
+    /** \brief Set up for data processing offline.
       * Performs the same initialization as in setup, in the abscence of a ros::NodeHandle.
-      * this method is useful if unpacking data directly from bag files, without passing 
+      * this method is useful if unpacking data directly from bag files, without passing
       * through a communication overhead.
-      * 
+      *
       * @param calibration_file path to the calibration file
       * @param max_range_ cutoff for maximum range
       * @param min_range_ cutoff for minimum range
@@ -166,8 +162,7 @@ namespace velodyne_rawdata
     int setupOffline(std::string calibration_file, double max_range_, double min_range_);
 
     void unpack(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
-//    void unpack(const velodyne_msgs::VelodynePacket &pkt, XYZIRBPointCloud &pc);
-    
+
     void setParameters(double min_range, double max_range, double view_direction,
                        double view_width);
 
@@ -180,34 +175,30 @@ namespace velodyne_rawdata
       double min_range;                ///< minimum range to publish
       int min_angle;                   ///< minimum angle to publish
       int max_angle;                   ///< maximum angle to publish
-      
+
       double tmp_min_angle;
       double tmp_max_angle;
     } Config;
     Config config_;
-    float previous_block_corrected_azimuth;    // for support of different scan patterns
-    float previous_block_corrected_elevation;  // record the scan profile endpoint in previous packet 
 
-    /** 
+    /**
      * Calibration file
      */
     velodyne_pointcloud::Calibration calibration_;
     float sin_rot_table_[ROTATION_MAX_UNITS];
     float cos_rot_table_[ROTATION_MAX_UNITS];
-    /** add private function to handle each sensor **/ 
+
+    // Caches the azimuth percent offset for the VLS-128 laser firings
+    float vls_128_laser_azimuth_cache[16];
+
+    /** add private function to handle each sensor **/
     void unpack_vlp16(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
     void unpack_vlp32(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
     void unpack_hdl32(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
     void unpack_hdl64(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
     void unpack_vls128(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
-    void compute_xyzi( const uint8_t chan_id
-                     , const uint16_t azimuth_uint
-                     , const float distance
-                     , float &intensity
-                     , float &x_coord
-                     , float &y_coord
-                     , float &z_coord
-                     ); 
+    void compute_xyzi(const uint8_t chan_id, const uint16_t azimuth_uint, const float distance, float &intensity,
+      float &x_coord, float &y_coord, float &z_coord);
 
     /** in-line test whether a point is in range */
     bool pointInRange(float range)
@@ -218,13 +209,5 @@ namespace velodyne_rawdata
   };
 
 } // namespace velodyne_rawdata
-  POINT_CLOUD_REGISTER_POINT_STRUCT(velodyne_rawdata::PointXYZIRB,
-		(float, x, x)
-                (float, y, y)
-                (float, z, z)
-                (float, intensity, intensity)
-                (uint16_t, ring,  ring)
-                (uint16_t, block, block))
-
 
 #endif // __VELODYNE_RAWDATA_H

--- a/velodyne_pointcloud/launch/VLS128_points.launch
+++ b/velodyne_pointcloud/launch/VLS128_points.launch
@@ -1,7 +1,7 @@
 <!-- -*- mode: XML -*- -->
 <!-- Copyright (C) 2018, Velodyne LiDAR INC., Algorithms and Signal Processing Group -->
 <!-- Author : Velodyne LiDAR, Algorithms and Signal Processing Group -->
-<!-- run velodyne_pointcloud/CloudNodelet in a nodelet manager for an VLS128 -->
+<!-- run velodyne_pointcloud/CloudNodelet in a nodelet manager for a VLS-128 -->
 
 <launch>
 
@@ -11,11 +11,10 @@
   <arg name="device_ip" default="" />
   <arg name="frame_id" default="velodyne" />
   <arg name="manager" default="$(arg frame_id)_nodelet_manager" />
-  <arg name="max_range" default="200.0" />
+  <arg name="max_range" default="300.0" />
   <arg name="min_range" default="0.4" />
-  <arg name="pcap" default=" " />
+  <arg name="pcap" default="" />
   <arg name="port" default="2368" />
-  <arg name="npackets" default="625" />
   <arg name="read_fast" default="false" />
   <arg name="read_once" default="false" />
   <arg name="repeat_delay" default="0.0" />
@@ -29,7 +28,6 @@
     <arg name="model" value="VLS128"/>
     <arg name="pcap" value="$(arg pcap)"/>
     <arg name="port" value="$(arg port)"/>
-    <arg name="npackets" value="$(arg npackets)"/>
     <arg name="read_fast" value="$(arg read_fast)"/>
     <arg name="read_once" value="$(arg read_once)"/>
     <arg name="repeat_delay" value="$(arg repeat_delay)"/>


### PR DESCRIPTION
# This adds the current VLS-128 driver I wrote for use at Voyage Auto.

* Adds timing changes for VLS-128.
* ~2x performance improvement due to removing unused calibration values and excessive calls to `compute_xyzi`.
* Improves performance in `unpack_vls128` by moving as much computation after the `pointInRange` check.

I found the overhead of calling `compute_xyzi` up to 2.4 million times per second could be reduced by running the function in the `unpack_vls128` function.

I also found a large amount of wasted computation in `compute_xyzi` that is only needed for the HDL-64 since the other velodynes don't have a device specific calibration file and run all of the calibration computation on the unit. The only thing used in the calibration file is `rot_correction`, `vert_correction`, and `laser_id`. Since all the other values are zero they don't add anything and only waste computation so I removed them. I will be translating this over to the other Velodynes in the public ROS driver soon.